### PR TITLE
Add step to bin/setup for git submodules

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -13,6 +13,9 @@ FileUtils.chdir APP_ROOT do
   # This script is idempotent, so that you can run it at anytime and get an expectable outcome.
   # Add necessary setup steps to this file.
 
+  puts '== Installing git submodules =='
+  system! 'git submodule init; git submodule update --init'
+
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')


### PR DESCRIPTION
Hey @manuelmeurer,

I believe we need git submodules installed before we can call `bundle install`. This fixes #49. 

Please check it out.

Thanks! 